### PR TITLE
A2-1461 Remove trailing slashes from links

### DIFF
--- a/itsm_api/views.py
+++ b/itsm_api/views.py
@@ -1458,7 +1458,7 @@ class UserCustomerList(flask_restful.Resource, ApiResourceList, _CustomerDataEmb
 
     """
 
-    URL                 = User.URL + "/customers/"
+    URL                 = User.URL + "/customers"
     VALID_SEARCH_FIELDS = CustomerList.VALID_SEARCH_FIELDS
 
     def _get(self, user_id, query=None):
@@ -1509,7 +1509,7 @@ class CustomerUserList(flask_restful.Resource, ApiResourceList, _UserDataEmbedde
 
     """
 
-    URL                 = Customer.URL + "/users/"
+    URL                 = Customer.URL + "/users"
     VALID_SEARCH_FIELDS = UserList.VALID_SEARCH_FIELDS
 
     def _get(self, customer_id, query=None):

--- a/test_itsm.py
+++ b/test_itsm.py
@@ -161,7 +161,7 @@ def test_create_edit_user(client):
     assert user_data['_links'] == {
         'self': {'href': '/users/5'},
         'contained_in': {'href': '/users'},
-        'customers': {'href': '/users/5/customers/'},
+        'customers': {'href': '/users/5/customers'},
         'tickets': {'href': '/users/5/tickets'}
     }
 
@@ -396,7 +396,7 @@ def test_customer_user_list(client):
         '_links': {
             'self': {'href': '/customers/1'},
             'contained_in': {'href': '/customers'},
-            'users': {'href': '/customers/1/users/'},
+            'users': {'href': '/customers/1/users'},
             'tickets': {'href': '/customers/1/tickets'},
             'parent': {'href': '/customers/3'}
         }
@@ -424,7 +424,7 @@ def test_customer_user_list(client):
             ]
         },
         '_links': {
-            'self': {'href': '/customers/1/users/'},
+            'self': {'href': '/customers/1/users'},
             'contained_in': {'href': '/customers/1'}
         }
     }
@@ -485,7 +485,7 @@ def test_user_customer_list(client):
             ],
         },
         '_links': {
-            'self': {'href': '/users/1/customers/'},
+            'self': {'href': '/users/1/customers'},
             'contained_in': {'href': '/users/1'}
         }
     }


### PR DESCRIPTION
Changes:
- Removed the trailing slashes from two links (`/users/<id>/customers/` and `/customers/<id>/users/`) to be consistent with other links.